### PR TITLE
feat: support groupmention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "forum": "https://discuss.flarum.org/d/18607"
   },
   "require": {
-    "flarum/core": "^1.3.1"
+    "flarum/core": "^1.6.2"
   },
   "replace": {
     "piotr-tokarczyk/flarum-user-default-preferences": "*"

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -7,3 +7,5 @@ fof-default-user-preferences:
       postMentioned-help: When enabled, new users will automatically opt into receiving an email notification when one of their posts is mentioned.
       userMentioned: User mentioned email
       userMentioned-help: When enabled, new users will automatically opt into receiving an email notification when they are @mentioned.
+      groupMentioned: Group mentioned email
+      groupMentioned-help: When enabled, new users will automatically opt into recieving an email notifiation when a group they belong to is mentioned.

--- a/src/Providers/DefaultUserPreferencesProvider.php
+++ b/src/Providers/DefaultUserPreferencesProvider.php
@@ -23,6 +23,7 @@ class DefaultUserPreferencesProvider extends AbstractServiceProvider
                 ['key' => 'postMentioned', 'value' => true, 'type' => 'bool'],
                 ['key' => 'userMentioned', 'value' => true, 'type' => 'bool'],
                 ['key' => 'followAfterReply', 'value' => true, 'type' => 'bool'],
+                ['key' => 'groupMentioned', 'value' => false, 'type' => 'bool'],
             ];
         });
 


### PR DESCRIPTION
Adds support for setting the default for `groupmention` emails

![image](https://user-images.githubusercontent.com/16573496/204371708-1e069a1b-d018-4b2b-a6e5-313ee99db259.png)
