### PR TITLE
[2.x] feat: add followAfterCreate default user preference

### DIFF
--- a/locale/en.yml
+++ b/locale/en.yml
@@ -7,6 +7,8 @@ fof-default-user-preferences:
       indexProfile-help: When enabled, new users will allow search engines to index their profile page, unless blocked by other site or extension settings.
       followAfterReply: Follow after reply
       followAfterReply-help: When enabled, new users will automatically follow discussions they reply to or comment on.
+      followAfterCreate: Follow after create
+      followAfterCreate-help: When enabled, new users will automatically follow discussions they create.
       postMentioned: Post mentioned email
       postMentioned-help: When enabled, new users will automatically opt into receiving an email notification when one of their posts is mentioned.
       userMentioned: User mentioned email

--- a/src/Providers/DefaultUserPreferencesProvider.php
+++ b/src/Providers/DefaultUserPreferencesProvider.php
@@ -25,6 +25,7 @@ class DefaultUserPreferencesProvider extends AbstractServiceProvider
                 ['key' => 'postMentioned', 'value' => true, 'type' => 'bool'],
                 ['key' => 'userMentioned', 'value' => true, 'type' => 'bool'],
                 ['key' => 'followAfterReply', 'value' => true, 'type' => 'bool'],
+                ['key' => 'followAfterCreate', 'value' => true, 'type' => 'bool'],
                 ['key' => 'groupMentioned', 'value' => false, 'type' => 'bool'],
             ];
         });


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

- Registered `followAfterCreate` boolean in `DefaultUserPreferencesProvider`
- Added frontend translation strings for the new toggle

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

<img width="758" height="885" alt="image" src="https://github.com/user-attachments/assets/d46f8cb3-e8d4-4ef9-ae26-f6c0ad70996a" />

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
